### PR TITLE
API URL moved from beta to www

### DIFF
--- a/django_peeringdb/settings.py
+++ b/django_peeringdb/settings.py
@@ -5,7 +5,7 @@ from django.conf import settings
 TABLE_PREFIX = getattr(settings, 'PEERINGDB_TABLE_PREFIX', 'peeringdb_')
 ABSTRACT_ONLY = getattr(settings, 'PEERINGDB_ABSTRACT_ONLY', False)
 
-SYNC_URL = getattr(settings, 'PEERINGDB_SYNC_URL', 'https://beta.peeringdb.com/api')
+SYNC_URL = getattr(settings, 'PEERINGDB_SYNC_URL', 'https://www.peeringdb.com/api')
 SYNC_USERNAME = getattr(settings, 'PEERINGDB_SYNC_USERNAME', '')
 SYNC_PASSWORD = getattr(settings, 'PEERINGDB_SYNC_PASSWORD', '')
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ default `False`
 Only load abstract models
 
 #### PEERINGDB_SYNC_URL
-default `'https://beta.peeringdb.com/api'`
+default `'https://www.peeringdb.com/api'`
 PeeringDB API endpoint URL
 
 #### PEERINGDB_SYNC_USERNAME

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 
 site_name: Django PeeringDB
-site_url: https://beta.peeringdb.com/
+site_url: https://www.peeringdb.com/
 site_description: Django PeeringDB module
 
 repo_url: https://github.com/peeringdb/django-peeringdb


### PR DESCRIPTION
Alas there are still some beta's in the code ...

    $ fgrep beta.peeringdb.com `find * -type f -print`
    django_peeringdb/settings.py:SYNC_URL = getattr(settings, 'PEERINGDB_SYNC_URL', 'https://beta.peeringdb.com/api')
    docs/index.md:default `'https://beta.peeringdb.com/api'`
    mkdocs.yml:site_url: https://beta.peeringdb.com/
    $

I assume this should be updated? I've edited them `s/beta/www/g` and hence this pull request.
