### PR TITLE
ugettext_lazy -> gettext_lazy

### DIFF
--- a/src/django_peeringdb/models/concrete.py
+++ b/src/django_peeringdb/models/concrete.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django_peeringdb.models import (
     ContactBase,


### PR DESCRIPTION
ImportError: cannot import name 'ugettext_lazy' from 'django.utils.translation' 
https://github.com/peeringdb/peeringdb-py/issues/60